### PR TITLE
	fix(messages): reading routing key from headers is part of interface and available in all impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ composer.lock
 vendor/
 
 # Eclipse files
+.project
 .buildpath
 .settings/
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev" : {
         "phpunit/phpunit" : "~5.3",
-        "empi89/php-amqp-stubs": "dev-master"
+        "empi89/php-amqp-stubs": "dev-master",
+        "puzzle/assert": "~1.0"
     },
     "suggests": {
         "ext-amqp": "PECL AMQP extension is required"

--- a/src/Messages/InMemoryJson.php
+++ b/src/Messages/InMemoryJson.php
@@ -34,4 +34,16 @@ class InMemoryJson extends Json implements ReadableMessage, WritableMessage
     {
         
     }
+    
+    public function getRoutingKeyFromHeader()
+    {
+        $headers = $this->getHeaders();
+        
+        if(! array_key_exists('routing_key', $headers))
+        {
+            return null;
+        }
+        
+        return $headers['routing_key'];
+    }
 }

--- a/src/ReadableMessage.php
+++ b/src/ReadableMessage.php
@@ -15,4 +15,6 @@ interface ReadableMessage extends Message
     public function isLastRetry();
     
     public function applyHooks(MessageHookCollection $messageHookCollection);
+    
+    public function getRoutingKeyFromHeader();
 }

--- a/tests/Messages/InMemoryJsonTest.php
+++ b/tests/Messages/InMemoryJsonTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Puzzle\AMQP\Messages;
+
+class InMemoryJsonTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetRoutingKeyFromHeaders()
+    {
+        $routingKey = 'pony.under.burgers';
+        $message = new InMemoryJson($routingKey);
+        
+        $this->assertNull($message->getRoutingKeyFromHeader());
+        
+        // Simulate client publishing that add this header
+        $message->addHeader('routing_key', $routingKey);
+        
+        $this->assertSame($routingKey, $message->getRoutingKeyFromHeader());
+    }
+}


### PR DESCRIPTION
Rebase, NOT squash (atomical commits inside)