### PR TITLE
feat(message): allow customizing content_type without breaking body decoding (introduce transport_content_type header)

### DIFF
--- a/src/MessageMetadata.php
+++ b/src/MessageMetadata.php
@@ -19,6 +19,11 @@ interface MessageMetadata
     public function getContentType();
 
     /**
+     * @return string
+     */
+    public function getTransportContentType();
+
+    /**
      * @return array
      */
     public function getHeaders();

--- a/src/Messages/InMemory.php
+++ b/src/Messages/InMemory.php
@@ -28,6 +28,7 @@ class InMemory
             'routing_key' => $routingKey,
             'app_id' => 'memory',
             'message_datetime' => date('Y-m-d H:i:s'),
+            'transport_content_type' => $body->getContentType(),
         ], $additionalHeaders);
 
         return new MessageAdapter(

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -15,6 +15,7 @@ class Message implements WritableMessage, ConvertibleToString
         $body,
         $canBeDroppedSilently,
         $allowCompression,
+        $contentType,
         $headers,
         $attributes;
 
@@ -24,6 +25,7 @@ class Message implements WritableMessage, ConvertibleToString
         
         $this->canBeDroppedSilently = true;
         $this->allowCompression = false;
+        $this->contentType = false;
         
         $this->headers = array();
         $this->initializeAttributes();
@@ -86,7 +88,24 @@ class Message implements WritableMessage, ConvertibleToString
 
     public function getContentType()
     {
+        if($this->contentType !== false)
+        {
+            return $this->contentType;
+        }
+
+        return $this->getTransportContentType();
+    }
+
+    public function getTransportContentType()
+    {
         return $this->body->getContentType();
+    }
+
+    public function setContentType($contentType)
+    {
+        $this->contentType = $contentType;
+
+        return $this;
     }
 
     public function getRoutingKey()
@@ -109,7 +128,7 @@ class Message implements WritableMessage, ConvertibleToString
     
     private function updateContentType()
     {
-        $this->attributes['content_type'] = $this->body->getContentType();
+        $this->attributes['content_type'] = $this->getContentType();
     }
 
     public function addHeader($headerName, $value)
@@ -160,6 +179,7 @@ class Message implements WritableMessage, ConvertibleToString
     private function packHeaders($timestamp)
     {
         $this->headers['message_datetime'] = date('Y-m-d H:i:s', $timestamp);
+        $this->headers['transport_content_type'] = $this->getTransportContentType();
 
         return $this->headers;
     }

--- a/src/Messages/Message.php
+++ b/src/Messages/Message.php
@@ -88,7 +88,7 @@ class Message implements WritableMessage, ConvertibleToString
 
     public function getContentType()
     {
-        if($this->contentType !== false)
+        if(! empty($this->contentType))
         {
             return $this->contentType;
         }

--- a/src/Messages/Processors/GZip.php
+++ b/src/Messages/Processors/GZip.php
@@ -141,7 +141,7 @@ class GZip implements OnPublishProcessor, OnConsumeProcessor
         $headers = $message->getHeaders();
         $newContentType = $headers[self::HEADER_COMPRESSION_CONTENT_TYPE];
         
-        $newBody = (new BodyFactory())->create($newContentType, $uncompressedContent);
+        $newBody = (new BodyFactory())->create($message->getTransportContentType(), $uncompressedContent);
         
         $builder
             ->changeBody($newBody)

--- a/src/Workers/MessageAdapter.php
+++ b/src/Workers/MessageAdapter.php
@@ -17,7 +17,7 @@ class MessageAdapter implements ReadableMessage
         $this->message = $message;
         
         $this->body = (new BodyFactory())->create(
-            $this->getContentType(),
+            $this->getTransportContentType(),
             $message->getBody()
         );
     }
@@ -30,6 +30,11 @@ class MessageAdapter implements ReadableMessage
     public function getContentType()
     {
         return $this->getAttribute('content_type');
+    }
+
+    public function getTransportContentType()
+    {
+        return $this->getHeader('transport_content_type');
     }
 
     public function getAppId()

--- a/src/Workers/ReadableMessageModifier.php
+++ b/src/Workers/ReadableMessageModifier.php
@@ -128,6 +128,11 @@ class ReadableMessageModifier
             }
         }
         
+        if($this->newBody instanceof Body)
+        {
+            $headers['transport_content_type'] = $this->newBody->getContentType();
+        }
+
         foreach($this->newHeaders as $name => $value)
         {
             $headers[$name] = $value;

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -43,6 +43,34 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('transport_content_type', $headers);
         $this->assertSame(ContentType::TEXT, $headers['transport_content_type']);
+
+        $msg->setText('<burger><bread><sauce /><cheese /><meat /></bread></burger>');
+        $msg->setContentType('');
+
+        $attributes = $msg->packAttributes();
+
+        $this->assertArrayHasKey('content_type', $attributes);
+        $this->assertSame(ContentType::TEXT, $attributes['content_type']);
+
+        $this->assertArrayHasKey('headers', $attributes);
+        $headers = $attributes['headers'];
+
+        $this->assertArrayHasKey('transport_content_type', $headers);
+        $this->assertSame(ContentType::TEXT, $headers['transport_content_type']);
+
+        $msg->setJson([]);
+        $msg->setContentType(null);
+
+        $attributes = $msg->packAttributes();
+
+        $this->assertArrayHasKey('content_type', $attributes);
+        $this->assertSame(ContentType::JSON, $attributes['content_type']);
+
+        $this->assertArrayHasKey('headers', $attributes);
+        $headers = $attributes['headers'];
+
+        $this->assertArrayHasKey('transport_content_type', $headers);
+        $this->assertSame(ContentType::JSON, $headers['transport_content_type']);
     }
 
     public function testPackAttributes()

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -14,6 +14,37 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(json_encode($json), $msg->getBodyInTransportFormat());
     }
     
+    public function testContentType()
+    {
+        $msg = new Message('deuteranope.rex');
+        $msg->setJson([]);
+
+        $attributes = $msg->packAttributes();
+
+        $this->assertArrayHasKey('content_type', $attributes);
+        $this->assertSame(ContentType::JSON, $attributes['content_type']);
+
+        $this->assertArrayHasKey('headers', $attributes);
+        $headers = $attributes['headers'];
+
+        $this->assertArrayHasKey('transport_content_type', $headers);
+        $this->assertSame(ContentType::JSON, $headers['transport_content_type']);
+
+        $msg->setText('memory leak');
+        $msg->setContentType('application/x-julian');
+
+        $attributes = $msg->packAttributes();
+
+        $this->assertArrayHasKey('content_type', $attributes);
+        $this->assertSame('application/x-julian', $attributes['content_type']);
+
+        $this->assertArrayHasKey('headers', $attributes);
+        $headers = $attributes['headers'];
+
+        $this->assertArrayHasKey('transport_content_type', $headers);
+        $this->assertSame(ContentType::TEXT, $headers['transport_content_type']);
+    }
+
     public function testPackAttributes()
     {
         $msg = new Message('pony.black_unicorn');
@@ -110,7 +141,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         ]);
         $message->addHeader('location', 'unknown');
 
-        $expectedHeaders = ['meal', 'pet', 'drink', 'location', 'message_datetime'];
+        $expectedHeaders = ['meal', 'pet', 'drink', 'location', 'message_datetime', 'transport_content_type'];
         $this->assertSameArrayExceptOrder(
             $expectedHeaders,
             array_keys($message->getHeaders())

--- a/tests/Messages/Processors/GZipTest.php
+++ b/tests/Messages/Processors/GZipTest.php
@@ -140,14 +140,15 @@ class GZipTest extends \PHPUnit_Framework_TestCase
             new Binary(gzencode($originalText)),
             [
                 Gzip::HEADER_COMPRESSION => Gzip::COMPRESSION_ALGORITHM,
-                GZip::HEADER_COMPRESSION_CONTENT_TYPE => ContentType::TEXT
+                GZip::HEADER_COMPRESSION_CONTENT_TYPE => 'application/custom',
+                'transport_content_type' => ContentType::TEXT,
             ]
         );
         
         $gzip = new GZip();
         $message = $gzip->onConsume($message);
 
-        $this->assertCompressionHeadersAreNotPresent($message, ContentType::TEXT);
+        $this->assertCompressionHeadersAreNotPresent($message, 'application/custom');
         $this->assertSame($originalText, $message->getBodyInOriginalFormat());
     }
     

--- a/tests/Workers/ProcessInterfaceAdapterTest.php
+++ b/tests/Workers/ProcessInterfaceAdapterTest.php
@@ -60,6 +60,9 @@ class ProcessInterfaceAdapterTest extends \PHPUnit_Framework_TestCase
         $message = new Message('body', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
+            'headers' => [
+                'transport_content_type' => ContentType::TEXT,
+            ],
         ]);
         $processor->process($message, []);
 
@@ -82,6 +85,9 @@ class ProcessInterfaceAdapterTest extends \PHPUnit_Framework_TestCase
         $processor->process(new Message('horse', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
+            'headers' => [
+                'transport_content_type' => ContentType::TEXT,
+            ],
         ]), []);
         
         $this->assertSame('pony', $worker->lastProcessedMessages->getBodyInOriginalFormat());
@@ -89,6 +95,9 @@ class ProcessInterfaceAdapterTest extends \PHPUnit_Framework_TestCase
         $processor->process(new Message('lamb', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
+            'headers' => [
+                'transport_content_type' => ContentType::TEXT,
+            ],
         ]), []);
         
         $this->assertSame('pony', $worker->lastProcessedMessages->getBodyInOriginalFormat());
@@ -98,6 +107,9 @@ class ProcessInterfaceAdapterTest extends \PHPUnit_Framework_TestCase
         $processor->process(new Message('donkey', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
+            'headers' => [
+                'transport_content_type' => ContentType::TEXT,
+            ],
         ]), []);
         
         $this->assertSame('pony', $worker->lastProcessedMessages->getBodyInOriginalFormat());
@@ -111,6 +123,9 @@ class ProcessInterfaceAdapterTest extends \PHPUnit_Framework_TestCase
         $processor->process(new Message('donkey', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
+            'headers' => [
+                'transport_content_type' => ContentType::TEXT,
+            ],
         ]), []);
         
         $this->assertSame('pegasus', $worker->lastProcessedMessages->getBodyInOriginalFormat());


### PR DESCRIPTION
Closes #34

if GTM, go to tag 3.0.0