### PR TITLE
Catch Throwable when consuming a message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-    - 5.6
     - 7.0
     - 7.1
+    - 7.2
 
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Puzzle AMQP  ![PHP >= 5.6](https://img.shields.io/badge/php-%3E%3D%205.6-blue.svg)
+Puzzle AMQP  ![PHP >= 7.0](https://img.shields.io/badge/php-%3E%3D%207.0-blue.svg)
 ===========
+
+PHP 5.6 users, please use < 5.x versions.
 
 QA
 --
@@ -8,7 +10,7 @@ QA
 
 Service | Result
 --- | ---
-**Travis CI** (PHP 5.6 .. 7.1) | [![Build Status](https://travis-ci.org/puzzle-org/amqp.svg?branch=master)](https://travis-ci.org/puzzle-org/amqp)
+**Travis CI** (PHP 7.0 .. 7.2) | [![Build Status](https://travis-ci.org/puzzle-org/amqp.svg?branch=master)](https://travis-ci.org/puzzle-org/amqp)
 **Scrutinizer** | [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/puzzle-org/amqp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/puzzle-org/amqp/?branch=master)
 **Code coverage** | [![codecov](https://codecov.io/gh/puzzle-org/amqp/branch/master/graph/badge.svg)](https://codecov.io/gh/puzzle-org/amqp)
 **Packagist** | [![Latest Stable Version](https://poser.pugx.org/puzzle/amqp/v/stable.png)](https://packagist.org/packages/puzzle/amqp) [![Total Downloads](https://poser.pugx.org/puzzle/amqp/downloads.svg)](https://packagist.org/packages/puzzle/amqp)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ class ExampleWorker implements Worker
 BC Breaks changelog
 -------------------
 
+**4.x -> 5.x**
+
+ - Drop support for php 5.6
+ - Worker now catch Throwable, not only Exceptions
+
 **3.x -> 4.x**
 
  - Chunk management introduced in 3.1 has been refactored and made easier : just use Streamed* bodies and same client as usual 

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
         }
     },
     "require" : {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "puzzle/configuration" : ">=3.0",
         "puzzle/pieces" : "~2.2",
         "symfony/console": "~3.2",
         "swarrot/swarrot": "~2.3",
         "knplabs/gaufrette": "~0.2",
         "symfony/event-dispatcher": "~3.2",
-        "puzzle/uuid": "^1.0.3 || ^2.0.1"
+        "puzzle/uuid": "^2.0.1"
     },
     "repositories": [
         {
@@ -35,7 +35,7 @@
         }
     ],
     "require-dev" : {
-        "phpunit/phpunit" : "~5.7",
+        "phpunit/phpunit" : "~6.0",
         "empi89/php-amqp-stubs": "dev-master",
         "puzzle/assert": "~1.1",
         "pimple/pimple": "~3.0",
@@ -44,8 +44,7 @@
         "alchemy/rabbitmq-management-client": "dev-retrieve-messages@dev",
         "symfony/debug": "~3.2",
         "doctrine/instantiator": "<1.1",
-        "doctrine/collections": "<=1.4.0",
-        "puzzle/uuid": "^1.0.3"
+        "doctrine/collections": "<=1.4.0"
     },
     "suggest": {
         "ext-amqp": "PECL AMQP extension is required",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     ],
     "require-dev" : {
-        "phpunit/phpunit" : "~6.0",
+        "phpunit/phpunit" : "~7.0",
         "empi89/php-amqp-stubs": "dev-master",
         "puzzle/assert": "~1.1",
         "pimple/pimple": "~3.0",

--- a/docker/docker-compose.yml-dist
+++ b/docker/docker-compose.yml-dist
@@ -9,7 +9,7 @@ services:
         links:
             - rabbitmq
     rabbitmq:
-        image: rabbitmq:3-management-alpine
+        image: rabbitmq:3.6-management-alpine
         container_name: puzzle-amqp-rabbitmq
         hostname: rabbitmq-puzzle-amqp
         ports:

--- a/docker/images/apache/Dockerfile
+++ b/docker/images/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-cli
+FROM php:7.2-cli
 
 RUN echo 'APT::Install-Recommends "0";' >>/etc/apt/apt.conf.d/99-recommends && \
     echo 'APT::Install-Suggests "0";' >>/etc/apt/apt.conf.d/99-suggests

--- a/docker/images/phpunit/whalephant.yml
+++ b/docker/images/phpunit/whalephant.yml
@@ -1,8 +1,8 @@
 name: puzzle-amqp
 php:
-    version: 5.6
+    version: 7.2
 extensions:
-    - xdebug:2.5.5
+    - xdebug
 ini:
     - "error_reporting = E_ALL;"
     - "xdebug.var_display_max_depth = 5;"

--- a/env/master.conf
+++ b/env/master.conf
@@ -1,7 +1,7 @@
 [Variables]
 
 amqp.host:
-    behat = rabbitmq
+    behat = puzzle-amqp-rabbitmq
     
 amqp.port:
     behat = 5672

--- a/features/bootstrap/ConsumeContext.php
+++ b/features/bootstrap/ConsumeContext.php
@@ -88,7 +88,7 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
      */
     public function iHaveConsumedMessage($nbMessages)
     {
-        \PHPUnit_Framework_Assert::assertSame((int) $nbMessages, count($this->consumedMessages));
+        \PHPUnit\Framework\Assert::assertSame((int) $nbMessages, count($this->consumedMessages));
     }
     
     /**
@@ -111,8 +111,8 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
     {
         $firstMessage = $this->consumedMessages[0];
         
-        \PHPUnit_Framework_Assert::assertSame($firstMessage->getRoutingKeyFromHeader(), $routingKey);
-        \PHPUnit_Framework_Assert::assertSame($firstMessage->getContentType(), $contentType);
+        \PHPUnit\Framework\Assert::assertSame($firstMessage->getRoutingKeyFromHeader(), $routingKey);
+        \PHPUnit\Framework\Assert::assertSame($firstMessage->getContentType(), $contentType);
     }
     
     /**
@@ -130,7 +130,7 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
     {
         $firstMessage = $this->consumedMessages[0];
         
-        \PHPUnit_Framework_Assert::assertSame($firstMessage->getBodyInOriginalFormat(), $bodyContent);
+        \PHPUnit\Framework\Assert::assertSame($firstMessage->getBodyInOriginalFormat(), $bodyContent);
     }
 
     /**
@@ -162,8 +162,8 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
             }
         }
         
-        \PHPUnit_Framework_Assert::assertNotNull($found);
-        \PHPUnit_Framework_Assert::assertSame($routingKey, $found->getRoutingKeyFromHeader());
+        \PHPUnit\Framework\Assert::assertNotNull($found);
+        \PHPUnit\Framework\Assert::assertSame($routingKey, $found->getRoutingKeyFromHeader());
     }
     
     /**
@@ -190,7 +190,7 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
             }
         }
         
-        \PHPUnit_Framework_Assert::assertTrue($found);
+        \PHPUnit\Framework\Assert::assertTrue($found);
     }
 
     /**

--- a/features/bootstrap/SendContext.php
+++ b/features/bootstrap/SendContext.php
@@ -71,7 +71,7 @@ class SendContext extends AbstractRabbitMQContext
     {
         $result = $this->client->publish($this->exchange, $message);
         
-        \PHPUnit_Framework_Assert::assertTrue($result);
+        \PHPUnit\Framework\Assert::assertTrue($result);
     }
     
     /**
@@ -113,14 +113,14 @@ class SendContext extends AbstractRabbitMQContext
     {
         $message = $this->theMessageInQueueContains(self::TEXT_ROUTING_KEY, false, $queueName, ContentType::BINARY);
 
-        \PHPUnit_Framework_Assert::assertArrayHasKey('headers', $message->properties);
+        \PHPUnit\Framework\Assert::assertArrayHasKey('headers', $message->properties);
         $headers = $message->properties['headers'];
 
-        \PHPUnit_Framework_Assert::assertTrue(is_array($headers));
-        \PHPUnit_Framework_Assert::assertArrayHasKey(GZip::HEADER_COMPRESSION, $headers);
-        \PHPUnit_Framework_Assert::assertArrayHasKey(GZip::HEADER_COMPRESSION_CONTENT_TYPE, $headers);
-        \PHPUnit_Framework_Assert::assertSame(Gzip::COMPRESSION_ALGORITHM, $headers[Gzip::HEADER_COMPRESSION]);
-        \PHPUnit_Framework_Assert::assertSame(ContentType::TEXT, $headers[Gzip::HEADER_COMPRESSION_CONTENT_TYPE]);
+        \PHPUnit\Framework\Assert::assertTrue(is_array($headers));
+        \PHPUnit\Framework\Assert::assertArrayHasKey(GZip::HEADER_COMPRESSION, $headers);
+        \PHPUnit\Framework\Assert::assertArrayHasKey(GZip::HEADER_COMPRESSION_CONTENT_TYPE, $headers);
+        \PHPUnit\Framework\Assert::assertSame(Gzip::COMPRESSION_ALGORITHM, $headers[Gzip::HEADER_COMPRESSION]);
+        \PHPUnit\Framework\Assert::assertSame(ContentType::TEXT, $headers[Gzip::HEADER_COMPRESSION_CONTENT_TYPE]);
     }
     
     private function theMessageInQueueContains($routingKey, $content, $queueName, $contentType)
@@ -128,12 +128,12 @@ class SendContext extends AbstractRabbitMQContext
         $messages = $this->api->getMessagesFromQueue($this->vhost(), $queueName);
         $message = $messages->first();
         
-        \PHPUnit_Framework_Assert::assertSame($routingKey, $message->routing_key);
-        \PHPUnit_Framework_Assert::assertSame($contentType, $message->properties['content_type']);
+        \PHPUnit\Framework\Assert::assertSame($routingKey, $message->routing_key);
+        \PHPUnit\Framework\Assert::assertSame($contentType, $message->properties['content_type']);
 
         if($content !== false)
         {
-            \PHPUnit_Framework_Assert::assertSame($content, $message->payload);
+            \PHPUnit\Framework\Assert::assertSame($content, $message->payload);
         }
 
         return $message;
@@ -152,7 +152,7 @@ class SendContext extends AbstractRabbitMQContext
             $nbMessages = $this->nbMessagesInQueue($queue);
         }
         
-        \PHPUnit_Framework_Assert::assertSame($expectedNbMessages, $nbMessages);
+        \PHPUnit\Framework\Assert::assertSame($expectedNbMessages, $nbMessages);
     }
     
     private function nbMessagesInQueue($queueName)

--- a/makefiles/behat.mk
+++ b/makefiles/behat.mk
@@ -16,7 +16,7 @@ CONTAINER_SOURCE_PATH=/usr/src/puzzle-amqp
 #------------------------------------------------------------------------------
 # Helpers
 #------------------------------------------------------------------------------
-init: up wait configure
+init: composer-install up wait configure
 
 wait:
 	sleep 5
@@ -56,8 +56,7 @@ reconfigure: clean-configuration configure
 cli_exec = docker run -it --rm \
 	                 -v ${HOST_SOURCE_PATH}:${CONTAINER_SOURCE_PATH} \
 	                 -w ${CONTAINER_SOURCE_PATH} \
-	                 --link puzzle-amqp-rabbitmq:rabbitmq \
-	                 --net puzzleamqp_default \
+	                 --network 'container:puzzle-amqp-rabbitmq' \
 	                 puzzle-amqp/app-server \
 	                 $1
 

--- a/src/Workers/ProcessorInterfaceAdapter.php
+++ b/src/Workers/ProcessorInterfaceAdapter.php
@@ -37,13 +37,18 @@ class ProcessorInterfaceAdapter implements ProcessorInterface
         {
             $processResult = $this->workerContext->getWorker()->process($message);
         }
-        catch(\Exception $exception)
+        catch(\Throwable $exception)
         {
             $this->onWorkerProcessed();
 
+            if($exception instanceof \Error)
+            {
+                $exception = new \ErrorException($exception->getMessage(), $exception->getCode(), E_ERROR, $exception->getFile(), $exception->getLine(), $exception);
+            }
+
             throw $exception;
         }
-        
+
         $this->onWorkerProcessed();
 
         return $processResult;

--- a/tests/Clients/Decorators/PrefixedExchangesClientTest.php
+++ b/tests/Clients/Decorators/PrefixedExchangesClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Puzzle\AMQP\Clients\Decorators;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Clients\InMemory;
 use Psr\Log\NullLogger;
 use Puzzle\AMQP\Client;
@@ -16,7 +17,7 @@ class MockedClient extends InMemory implements Client
     }
 }
 
-class PrefixedExchangesClientTest extends \PHPUnit_Framework_TestCase
+class PrefixedExchangesClientTest extends TestCase
 {
     private
         $memory;

--- a/tests/Clients/Decorators/PrefixedQueuesClientTest.php
+++ b/tests/Clients/Decorators/PrefixedQueuesClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Puzzle\AMQP\Clients\Decorators;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Client;
 use Puzzle\AMQP\Clients\InMemory;
 use Puzzle\AMQP\Messages\Message;
@@ -20,7 +21,7 @@ class MockedClientQueue extends InMemory implements Client
     }
 }
 
-class PrefixedQueuesClientTest extends \PHPUnit_Framework_TestCase
+class PrefixedQueuesClientTest extends TestCase
 {
     /**
      * @dataProvider providerTestGetQueue

--- a/tests/Clients/InMemoryTest.php
+++ b/tests/Clients/InMemoryTest.php
@@ -2,10 +2,11 @@
 
 namespace Puzzle\AMQP\Clients;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Messages\Message;
 use Puzzle\AMQP\Messages\Processors\NullProcessor;
 
-class InMemoryTest extends \PHPUnit_Framework_TestCase
+class InMemoryTest extends TestCase
 {
     public function testAll()
     {

--- a/tests/Messages/Bodies/BinaryTest.php
+++ b/tests/Messages/Bodies/BinaryTest.php
@@ -2,11 +2,12 @@
 
 namespace Puzzle\AMQP\Messages\Bodies;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Clients\InMemory;
 use Puzzle\AMQP\Messages\Message;
 use Puzzle\AMQP\Messages\ContentType;
 
-class BinaryTest extends \PHPUnit_Framework_TestCase
+class BinaryTest extends TestCase
 {
     public function testContentType()
     {

--- a/tests/Messages/Bodies/JsonTest.php
+++ b/tests/Messages/Bodies/JsonTest.php
@@ -2,7 +2,9 @@
 
 namespace Puzzle\AMQP\Messages\Bodies;
 
-class JsonTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class JsonTest extends TestCase
 {
     public function testGetContentInDifferentFormats()
     {

--- a/tests/Messages/Bodies/NullBodyTest.php
+++ b/tests/Messages/Bodies/NullBodyTest.php
@@ -2,7 +2,9 @@
 
 namespace Puzzle\AMQP\Messages\Bodies;
 
-class NullBodyTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class NullBodyTest extends TestCase
 {
     public function testNullBody()
     {

--- a/tests/Messages/Bodies/StreamedFileTest.php
+++ b/tests/Messages/Bodies/StreamedFileTest.php
@@ -2,11 +2,12 @@
 
 namespace Puzzle\AMQP\Messages\Bodies;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Clients\InMemory;
 use Puzzle\AMQP\Messages\Message;
 use Puzzle\AMQP\Messages\Chunks\ChunkSize;
 
-class classTest extends \PHPUnit_Framework_TestCase
+class classTest extends TestCase
 {
     public function testPublish()
     {

--- a/tests/Messages/Bodies/TextTest.php
+++ b/tests/Messages/Bodies/TextTest.php
@@ -2,7 +2,9 @@
 
 namespace Puzzle\AMQP\Messages\Bodies;
 
-class TextTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TextTest extends TestCase
 {
     /**
      * @dataProvider providerTestToString

--- a/tests/Messages/BodyFactories/StandardTest.php
+++ b/tests/Messages/BodyFactories/StandardTest.php
@@ -2,10 +2,11 @@
 
 namespace Puzzle\AMQP\Messages\BodyFactories;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Messages\ContentType;
 use Puzzle\AMQP\Messages\TypedBodyFactories\Json;
 
-class StandardTest extends \PHPUnit_Framework_TestCase
+class StandardTest extends TestCase
 {
     /**
      * @dataProvider providerTestBuild

--- a/tests/Messages/InMemoryTest.php
+++ b/tests/Messages/InMemoryTest.php
@@ -2,10 +2,11 @@
 
 namespace Puzzle\AMQP\Messages;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\ReadableMessage;
 use Puzzle\AMQP\Messages\Bodies\Text;
 
-class InMemoryTest extends \PHPUnit_Framework_TestCase
+class InMemoryTest extends TestCase
 {
     public function testGetRoutingKeyFromHeader()
     {

--- a/tests/Messages/MessageTest.php
+++ b/tests/Messages/MessageTest.php
@@ -2,10 +2,11 @@
 
 namespace Puzzle\AMQP\Messages;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\MessageMetadata;
 use Puzzle\AMQP\Messages\Chunks\ChunkSize;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     use \Puzzle\Assert\ArrayRelated;
 

--- a/tests/Messages/Processors/AddHeaderTest.php
+++ b/tests/Messages/Processors/AddHeaderTest.php
@@ -2,11 +2,12 @@
 
 namespace Puzzle\AMQP\Messages\Processors;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Messages\Message;
 use Puzzle\AMQP\Clients\InMemory;
 use Puzzle\AMQP\WritableMessage;
 
-class AddHeaderTest extends \PHPUnit_Framework_TestCase
+class AddHeaderTest extends TestCase
 {
     public function testOnPublish()
     {

--- a/tests/Messages/Processors/GZipTest.php
+++ b/tests/Messages/Processors/GZipTest.php
@@ -2,6 +2,7 @@
 
 namespace Puzzle\AMQP\Messages\Processors;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Messages\Message;
 use Puzzle\AMQP\Messages\ContentType;
 use Symfony\Component\Debug\BufferingLogger;
@@ -11,7 +12,7 @@ use Puzzle\AMQP\Messages\Bodies\Binary;
 use Puzzle\AMQP\MessageMetadata;
 use Puzzle\AMQP\Messages\Bodies\Json;
 
-class GZipTest extends \PHPUnit_Framework_TestCase
+class GZipTest extends TestCase
 {
     use ExampleDataProvider;
     

--- a/tests/Services/SupervisorConfigurationGeneratorTest.php
+++ b/tests/Services/SupervisorConfigurationGeneratorTest.php
@@ -4,9 +4,10 @@ namespace Puzzle\AMQP\Services;
 
 use Gaufrette\Filesystem;
 use Gaufrette\Adapter\InMemory;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\NullOutput;
 
-class SupervisorConfigurationGeneratorTest extends \PHPUnit_Framework_TestCase
+class SupervisorConfigurationGeneratorTest extends TestCase
 {
     /**
      * @dataProvider providerTestGenerate

--- a/tests/Workers/MessageAdapterFactoryAwareTest.php
+++ b/tests/Workers/MessageAdapterFactoryAwareTest.php
@@ -2,6 +2,7 @@
 
 namespace Puzzle\AMQP\Workers;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Messages\ContentType;
 
 class FooBar
@@ -9,7 +10,7 @@ class FooBar
     use MessageAdapterFactoryAware;
 }
 
-class MessageAdapterFactoryAwareTest extends \PHPUnit_Framework_TestCase
+class MessageAdapterFactoryAwareTest extends TestCase
 {
     public function testFallbackConstructionWithStandardImplementation()
     {

--- a/tests/Workers/MessageAdapterTest.php
+++ b/tests/Workers/MessageAdapterTest.php
@@ -2,6 +2,7 @@
 
 namespace Puzzle\AMQP\Workers;
 
+use PHPUnit\Framework\TestCase;
 use Swarrot\Broker\Message;
 use Puzzle\AMQP\Messages\ContentType;
 use Puzzle\AMQP\Messages\Bodies\Json;
@@ -10,7 +11,7 @@ use Puzzle\AMQP\Messages\InMemory;
 use Puzzle\AMQP\WritableMessage;
 use Puzzle\Assert\ArrayRelated;
 
-class MessageAdapterTest extends \PHPUnit_Framework_TestCase
+class MessageAdapterTest extends TestCase
 {
     use ArrayRelated;
 

--- a/tests/Workers/ProcessInterfaceAdapterTest.php
+++ b/tests/Workers/ProcessInterfaceAdapterTest.php
@@ -2,13 +2,13 @@
 
 namespace Puzzle\AMQP\Workers;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\ReadableMessage;
 use Puzzle\AMQP\Consumers\Simple;
 use Psr\Log\LoggerAwareTrait;
 use Swarrot\Broker\Message;
 use Puzzle\AMQP\Messages\ContentType;
 use Puzzle\AMQP\Messages\OnConsumeProcessor;
-use Puzzle\AMQP\Workers\ReadableMessageModifier;
 use Puzzle\AMQP\Messages\Bodies\Text;
 use Puzzle\Pieces\EventDispatcher\Adapters\Symfony;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -49,7 +49,7 @@ class Collect implements Worker
     }
 }
 
-class ProcessInterfaceAdapterTest extends \PHPUnit_Framework_TestCase
+class ProcessInterfaceAdapterTest extends TestCase
 {
     public function testProcess()
     {

--- a/tests/Workers/ProcessInterfaceAdapterTest.php
+++ b/tests/Workers/ProcessInterfaceAdapterTest.php
@@ -36,6 +36,26 @@ class ChangeBodyProcessor implements OnConsumeProcessor
     }
 }
 
+class CallableWorker implements Worker
+{
+    use LoggerAwareTrait;
+
+    private
+        $callable;
+
+    public function __construct($callable)
+    {
+        $this->callable = $callable;
+    }
+
+    public function process(ReadableMessage $message)
+    {
+        $callable = $this->callable;
+
+        $callable();
+    }
+}
+
 class Collect implements Worker
 {
     use LoggerAwareTrait;
@@ -70,7 +90,7 @@ class ProcessInterfaceAdapterTest extends TestCase
         $this->assertTrue($worker->lastProcessedMessages instanceof ReadableMessage);
         $this->assertSame('ponies.over.unicorns', $worker->lastProcessedMessages->getRoutingKey());
     }
-    
+
     public function testProcessWithCustomDependencies()
     {
         $worker = new Collect();
@@ -81,12 +101,12 @@ class ProcessInterfaceAdapterTest extends TestCase
         $workerContext = new WorkerContext($workerClosure, new Simple(), 'fake_queue');
         $bodyFactory = new Standard();
         $bodyFactory->handleContentType('application/x-custom', new \Puzzle\AMQP\Messages\TypedBodyFactories\Text());
-        
+
         $processor = new ProcessorInterfaceAdapter($workerContext);
         $processor
             ->setEventDispatcher(new Symfony(new EventDispatcher()))
             ->setMessageAdapterFactory(new MessageAdapterFactory($bodyFactory));
-        
+
         $message = new Message('body', [
             'content_type' => 'application/x-custom',
             'routing_key' => 'ponies.over.unicorns',
@@ -96,7 +116,7 @@ class ProcessInterfaceAdapterTest extends TestCase
         $this->assertTrue($worker->lastProcessedMessages instanceof ReadableMessage);
         $this->assertSame('ponies.over.unicorns', $worker->lastProcessedMessages->getRoutingKey());
     }
-    
+
     public function testOnConsume()
     {
         $worker = new Collect();
@@ -110,30 +130,30 @@ class ProcessInterfaceAdapterTest extends TestCase
 
         $processor = new ProcessorInterfaceAdapter($workerContext);
         $processor->appendMessageProcessor(new ChangeBodyProcessor('pony'));
-        
+
         $processor->process(new Message('horse', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
         ]), []);
-        
+
         $this->assertSame('pony', $worker->lastProcessedMessages->getBodyInOriginalFormat());
 
         $processor->process(new Message('lamb', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
         ]), []);
-        
+
         $this->assertSame('pony', $worker->lastProcessedMessages->getBodyInOriginalFormat());
-        
+
         $processor->appendMessageProcessor(new ChangeBodyProcessor('unicorn'));
 
         $processor->process(new Message('donkey', [
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
         ]), []);
-        
+
         $this->assertSame('pony', $worker->lastProcessedMessages->getBodyInOriginalFormat());
-        
+
         $processor->setMessageProcessors([
             new ChangeBodyProcessor('pegasus'),
             new ChangeBodyProcessor('unicorn'),
@@ -144,7 +164,66 @@ class ProcessInterfaceAdapterTest extends TestCase
             'content_type' => ContentType::TEXT,
             'routing_key' => 'ponies.over.unicorns',
         ]), []);
-        
+
         $this->assertSame('pegasus', $worker->lastProcessedMessages->getBodyInOriginalFormat());
+    }
+
+    /**
+     * @dataProvider providerTestCatchingThrowable
+     */
+    public function testCatchingThrowable(Worker $worker, $expectedException)
+    {
+        $workerContext = new WorkerContext(
+            function() use($worker) {
+                return $worker;
+            },
+            new Simple(),
+            'fake_queue'
+        );
+
+
+        $processor = new ProcessorInterfaceAdapter($workerContext);
+        $current = null;
+
+        // Workaround : PHPUnit set an error handler -> unable to catch PHP native \Error
+        // cf. http://php.net/manual/fr/function.set-error-handler.php
+        $errorHandler = set_error_handler(null);
+        try
+        {
+            $processor->process(new Message('body', [
+                'content_type' => ContentType::TEXT,
+                'routing_key' => 'ponies.over.unicorns',
+            ]), []);
+        }
+        catch(\Throwable $current)
+        {
+        }
+
+        set_error_handler($errorHandler);// Removing the workaround
+
+        $this->assertInstanceOf($expectedException, $current);
+    }
+
+    public function providerTestCatchingThrowable()
+    {
+        return [
+            'exception' => [
+                'worker' => $this->callableWorker(function() {
+                    throw new \Exception('Zboui zboui zboui');
+                }),
+                'expectedException' => \Exception::class,
+            ],
+            'error' => [
+                'worker' => $this->callableWorker(function() {
+                    throw new \Error('This is a PHP error');
+                }),
+                'expectedException' => \ErrorException::class,
+            ],
+        ];
+    }
+
+    private function callableWorker($callable): CallableWorker
+    {
+        return new CallableWorker($callable);
     }
 }

--- a/tests/Workers/Providers/PimpleTest.php
+++ b/tests/Workers/Providers/PimpleTest.php
@@ -2,6 +2,7 @@
 
 namespace Puzzle\AMQP\Workers\Providers;
 
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Puzzle\AMQP\Workers\WorkerContext;
 use Puzzle\AMQP\Consumers\Simple;
@@ -9,7 +10,7 @@ use Puzzle\AMQP\Messages\Processors\NullProcessor;
 use Puzzle\AMQP\Messages\Processor;
 use Puzzle\AMQP\Workers\WorkerProvider;
 
-class PimpleTest extends \PHPUnit_Framework_TestCase
+class PimpleTest extends TestCase
 {
     private
         $container;

--- a/tests/Workers/ReadableMessageModifierTest.php
+++ b/tests/Workers/ReadableMessageModifierTest.php
@@ -2,12 +2,13 @@
 
 namespace Puzzle\AMQP\Workers;
 
+use PHPUnit\Framework\TestCase;
 use Puzzle\AMQP\Messages\InMemory;
 use Puzzle\AMQP\Messages\ContentType;
 use Puzzle\AMQP\ReadableMessage;
 use Puzzle\AMQP\Messages\Bodies\Json;
 
-class ReadableMessageModifierTest extends \PHPUnit_Framework_TestCase
+class ReadableMessageModifierTest extends TestCase
 {
     private
         $originalMessage;


### PR DESCRIPTION
- drop support for php 5.6 (see branch php-5.6)
- worker now handle `\Throwable`
- update phpunit to `7.1`
- force rabbitmq version to `3.6` because of the dependency `alchemy/rabbitmq-management-client` throwing exception with `3.7` (`Entity RabbitMQ\Management\Entity\Queue does not have property effective_policy_definition (InvalidArgumentException)`)