### PR TITLE
poc: nack message on a fatal error

### DIFF
--- a/src/Consumers/AbstractConsumer.php
+++ b/src/Consumers/AbstractConsumer.php
@@ -48,6 +48,7 @@ abstract class AbstractConsumer implements Consumer
     protected function getBaseStack()
     {
         $stack = (new Stack\Builder())
+            ->push('Puzzle\AMQP\Processors\FatalErrorNack', $this->messageProvider)
             ->push('Swarrot\Processor\SignalHandler\SignalHandlerProcessor', $this->logger)
             ->push('Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor', $this->logger)
         ;

--- a/src/Processors/FatalErrorNack.php
+++ b/src/Processors/FatalErrorNack.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Puzzle\AMQP\Processors;
+
+use Psr\Log\LoggerInterface;
+use Swarrot\Broker\MessageProvider\MessageProviderInterface;
+use Swarrot\Processor\ProcessorInterface;
+use Swarrot\Broker\Message;
+
+class FatalErrorNack implements ProcessorInterface
+{
+    public function __construct(ProcessorInterface $processor, MessageProviderInterface $messageProvider)
+    {
+        $this->processor = $processor;
+        $this->messageProvider = $messageProvider;
+    }
+
+    public function process(Message $message, array $options)
+    {
+        $messageProvider = $this->messageProvider;
+
+        register_shutdown_function(function() use($messageProvider, $message) {
+            $error = error_get_last();
+
+            if(null !== $error)
+            {
+                if($error["type"] === E_ERROR)
+                {
+                    $messageProvider->nack($message);
+                }
+            }
+        });
+
+        return $this->processor->process($message, $options);
+    }
+}

--- a/src/Processors/Readme.md
+++ b/src/Processors/Readme.md
@@ -1,0 +1,10 @@
+# Custom Swarrot Processors
+
+**FatalErrorNack**
+
+`FatalErrorNack` is a swarrot processor that will nack the message if a fatal run-time errors occurs (E_ERROR).
+
+For example : 
+```
+PHP Fatal error:  Allowed memory size of XXX bytes exhausted (tried to allocate YYY bytes) in [...]
+```


### PR DESCRIPTION
Nack a message if a fatal error occurs. 
Example : `memory_limit` reached