### PR TITLE
Val 49 tests autovalidation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,16 @@
         "behat/behat": "~3.3",
         "symfony/debug": "~3.2",
         "doctrine/collections": "<=1.4.0",
-        "avto-dev/rabbitmq-api-client": "^2.0"
+        "groall/rabbitmq-http-api-client-php": "^0.2.3"
     },
     "repositories": [
         {
             "type": "vcs",
             "url": "https://github.com/naoned/rabbit-mq-admin-toolkit"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/naoned/rabbitmq-http-api-client-php "
         }
     ],
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "behat/behat": "~3.3",
         "symfony/debug": "~3.2",
         "doctrine/collections": "<=1.4.0",
-        "groall/rabbitmq-http-api-client-php": "^0.2.3"
+        "groall/rabbitmq-http-api-client-php": "^0.2.4"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "odolbeau/rabbit-mq-admin-toolkit": "~5.2.2",
         "behat/behat": "~3.3",
         "symfony/debug": "~3.2",
-        "doctrine/collections": "<=1.4.0"
+        "doctrine/collections": "<=1.4.0",
+        "avto-dev/rabbitmq-api-client": "^2.0"
     },
     "repositories": [
         {

--- a/features/bootstrap/AbstractRabbitMQContext.php
+++ b/features/bootstrap/AbstractRabbitMQContext.php
@@ -2,8 +2,6 @@
 
 namespace Puzzle\AMQP\Contexts;
 
-use AvtoDev\RabbitMqApiClient\Client;
-use AvtoDev\RabbitMqApiClient\ConnectionSettings;
 use Behat\Behat\Context\Context;
 use Puzzle\Configuration\Yaml;
 use Gaufrette\Filesystem;
@@ -22,8 +20,8 @@ abstract class AbstractRabbitMQContext implements Context
     
     protected Pecl
         $client;
-    protected Client
-        $avtoDevClient;
+    protected \RabbitMqHttpApiClient
+        $httpClient;
     protected string
         $vhost;
 
@@ -35,11 +33,12 @@ abstract class AbstractRabbitMQContext implements Context
         $this->client->appendMessageProcessor(new GZip());
 
         $rabbitConf = $configuration->readRequired('amqp/broker');
-        $this->avtoDevClient = new Client(new ConnectionSettings(
-            $rabbitConf['host'] . ':15672',
+        $this->httpClient = new \RabbitMqHttpApiClient(
+            $rabbitConf['host'],
+            15672,
             $rabbitConf['login'],
             $rabbitConf['password'],
-        ));
+        );
         $this->vhost = $rabbitConf['vhost'];
     }
 }

--- a/features/bootstrap/AbstractRabbitMQContext.php
+++ b/features/bootstrap/AbstractRabbitMQContext.php
@@ -2,14 +2,14 @@
 
 namespace Puzzle\AMQP\Contexts;
 
+use AvtoDev\RabbitMqApiClient\Client;
+use AvtoDev\RabbitMqApiClient\ConnectionSettings;
 use Behat\Behat\Context\Context;
 use Puzzle\Configuration\Yaml;
 use Gaufrette\Filesystem;
 use Gaufrette\Adapter\Local;
-use RabbitMQ\Management\APIClient;
 use Puzzle\AMQP\Clients\Pecl;
 use Puzzle\AMQP\Messages\Processors\GZip;
-use Puzzle\Configuration;
 
 abstract class AbstractRabbitMQContext implements Context
 {
@@ -22,6 +22,10 @@ abstract class AbstractRabbitMQContext implements Context
     
     protected Pecl
         $client;
+    protected Client
+        $avtoDevClient;
+    protected string
+        $vhost;
 
     public function __construct($path)
     {
@@ -29,5 +33,13 @@ abstract class AbstractRabbitMQContext implements Context
 
         $this->client = new Pecl($configuration);
         $this->client->appendMessageProcessor(new GZip());
+
+        $rabbitConf = $configuration->readRequired('amqp/broker');
+        $this->avtoDevClient = new Client(new ConnectionSettings(
+            $rabbitConf['host'] . ':15672',
+            $rabbitConf['login'],
+            $rabbitConf['password'],
+        ));
+        $this->vhost = $rabbitConf['vhost'];
     }
 }

--- a/features/bootstrap/ConsumeContext.php
+++ b/features/bootstrap/ConsumeContext.php
@@ -27,6 +27,16 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
         $this->logger = new NullLogger();
         $this->consumedMessages = [];
     }
+
+    /**
+     * @Given The queue :queue contains only the text message :bodyContent
+     */
+    public function theQueueContainsOnlyTheTextMessage($bodyContent, $queue)
+    {
+        $this->httpClient->purgeQueue($this->vhost, $queue);
+
+        $this->theQueueContainsTheTextMessage($bodyContent, $queue);
+    }
     
     /**
      * @Given The queue :queue contains the text message :bodyContent
@@ -184,6 +194,16 @@ class ConsumeContext extends AbstractRabbitMQContext implements Worker
         }
         
         \PHPUnit\Framework\Assert::assertTrue($found);
+    }
+
+    /**
+     * @Given The queue :queue contains only the compressed text message :bodyContent
+     */
+    public function theQueueContainsOnlyTheCompressedTextMessage($bodyContent, $queue)
+    {
+        $this->httpClient->purgeQueue($this->vhost, $queue);
+
+        $this->theQueueContainsTheCompressedTextMessage($bodyContent, $queue);
     }
 
     /**

--- a/features/bootstrap/SendContext.php
+++ b/features/bootstrap/SendContext.php
@@ -156,10 +156,6 @@ class SendContext extends AbstractRabbitMQContext
     
     private function nbMessagesInQueue(string $queueName): int
     {
-        $queue = $this->client->getQueue($queueName);
-
-        $queue->setFlags(AMQP_DURABLE);
-
-        return $queue->declareQueue();
+        return $this->avtoDevClient->queueInfo($queueName, $this->vhost)->getMessagesCount();
     }
 }

--- a/features/consume.feature
+++ b/features/consume.feature
@@ -1,7 +1,8 @@
 Feature: Consuming AMQP messages
 
 Scenario: Consuming a text message
-    Given The queue 'test_1' contains the text message "Puzzle is great"
+    Given The queue 'test_1' is empty
+    And The queue 'test_1' contains the text message "Puzzle is great"
     When I consume all the messages in the queue 'test_1'
     Then I have consumed 1 message
     And the message is a text one 
@@ -27,7 +28,8 @@ Scenario: Consuming many messages
     And one of the messages contains the json '{"lastName":"Poteau", "firstName":"Alexis"}'
 
 Scenario: Consuming a compressed text message
-    Given The queue 'test_zip' contains the compressed text message "Puzzle is great"
+    Given The queue 'test_zip' is empty
+    And The queue 'test_zip' contains the compressed text message "Puzzle is great"
     When I consume all the messages in the queue 'test_zip'
     Then I have consumed 1 message
     And the message is an uncompressed text one

--- a/features/consume.feature
+++ b/features/consume.feature
@@ -1,8 +1,7 @@
 Feature: Consuming AMQP messages
 
 Scenario: Consuming a text message
-    Given The queue 'test_1' is empty
-    And The queue 'test_1' contains the text message "Puzzle is great"
+    Given The queue 'test_1' contains only the text message "Puzzle is great"
     When I consume all the messages in the queue 'test_1'
     Then I have consumed 1 message
     And the message is a text one 
@@ -28,8 +27,7 @@ Scenario: Consuming many messages
     And one of the messages contains the json '{"lastName":"Poteau", "firstName":"Alexis"}'
 
 Scenario: Consuming a compressed text message
-    Given The queue 'test_zip' is empty
-    And The queue 'test_zip' contains the compressed text message "Puzzle is great"
+    Given The queue 'test_zip' contains only the compressed text message "Puzzle is great"
     When I consume all the messages in the queue 'test_zip'
     Then I have consumed 1 message
     And the message is an uncompressed text one


### PR DESCRIPTION
J'ai changé les validations en utilisant l'api http dans le module http.
Le purge ne me semblait pas pertinent a faire en curl, vu qu'on fait la validation en curl juste après.

Niveau réal c'était un peu l'aventure :

avto-dev/rabbitmq-api-client ne proposait pas de consomer les messages, j'ai du passer sur une autre lib :  https://github.com/groall/rabbitmq-http-api-client-php

La lib n'est pas sur packagist, j'ai donc forké  : https://github.com/naoned/rabbitmq-http-api-client-php
La méthode getMessages() de la lib ne fonctionnant pas, j'ai effectué les corrections sur le fork et sorti une 0.2.3

J'en ai profiter pour contribuer à la lib d'origine https://github.com/groall/rabbitmq-http-api-client-php/pull/2