### PR TITLE
fix(MessageAdapter): appId and contentType are nullable

### DIFF
--- a/src/MessageMetadata.php
+++ b/src/MessageMetadata.php
@@ -11,8 +11,8 @@ interface MessageMetadata
         PERSISTENT = 2;
 
     public function getRoutingKey(): string;
-    
-    public function getContentType(): string;
+
+    public function getContentType(): ?string;
 
     public function getHeaders(): array;
     

--- a/src/ReadableMessage.php
+++ b/src/ReadableMessage.php
@@ -10,7 +10,7 @@ interface ReadableMessage extends MessageMetadata
     
     public function getBodyAsTransported(): mixed;
 
-    public function getAppId(): string;
+    public function getAppId(): ?string;
 
     public function getAttributes(): array;
     

--- a/src/Workers/MessageAdapter.php
+++ b/src/Workers/MessageAdapter.php
@@ -34,12 +34,12 @@ class MessageAdapter implements ReadableMessage
         return $this->getAttribute('routing_key');
     }
 
-    public function getContentType(): string
+    public function getContentType(): ?string
     {
         return $this->getAttribute('content_type');
     }
 
-    public function getAppId(): string
+    public function getAppId(): ?string
     {
         return $this->getAttribute('app_id');
     }

--- a/tests/Workers/MessageAdapterTest.php
+++ b/tests/Workers/MessageAdapterTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Swarrot\Broker\Message;
 use Puzzle\AMQP\Messages\ContentType;
-use Puzzle\AMQP\Messages\Bodies\Json;
 use Puzzle\AMQP\Messages\Bodies\Text;
 use Puzzle\AMQP\Messages\InMemory;
 use Puzzle\AMQP\WritableMessage;
@@ -118,6 +117,45 @@ TEXT;
         $message = (new MessageAdapterFactory())->build($swarrotMessage);
 
         $message->getAttribute('not_an_amqp_attribute');
+    }
+
+    #[DataProvider('providerTestAppId')]
+    public function testAppId(?string $appId): void
+    {
+        $swarrotMessage = new Message('', [
+            'content_type' => ContentType::EMPTY_CONTENT,
+            'app_id' => $appId,
+        ]);
+        $message = (new MessageAdapterFactory())->build($swarrotMessage);
+
+        self::assertEquals($appId, $message->getAppId());
+    }
+
+    public static function providerTestAppId(): array
+    {
+        return [
+            'nominal' => ['killing_application'],
+            'is nullable' => [null],
+        ];
+    }
+
+    #[DataProvider('providerTestContentType')]
+    public function testContentType(?string $contentType): void
+    {
+        $swarrotMessage = new Message('', [
+            'content_type' => $contentType,
+        ]);
+        $message = (new MessageAdapterFactory())->build($swarrotMessage);
+
+        self::assertEquals($contentType, $message->getContentType());
+    }
+
+    public static function providerTestContentType(): array
+    {
+        return [
+            'nominal' => [ ContentType::BINARY ],
+            'is nullable' => [null],
+        ];
     }
 
     public function testInvalidConstruction(): void


### PR DESCRIPTION
`Swarrot\Broker\MessageProvider\PeclPackageMessageProvider` creates a `Swarrot\Broker\Message` with every possible properties (whereas `PhpAmqpLibMessageProvider` create a `Message` with only properties with values from the enveloppe)

`ContentType` and `AppId` are nullable

See
- https://github.com/php-amqp/php-amqp/blob/f6757c21634091b1d2baed18a37118f808f8f67f/stubs/AMQPBasicProperties.php#L72
- https://github.com/php-amqp/php-amqp/blob/f6757c21634091b1d2baed18a37118f808f8f67f/stubs/AMQPBasicProperties.php#L180