### PR TITLE
PHP  8.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.3', '8.4' ]
+        php-versions: [ '8.3', '8.4', '8.5' ]
     steps:
 
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ PHP 5.6 & 7.x users, please use < 5.x versions.
 QA
 --
 
-| Service                 | Result |
-|-------------------------| --- |
-| **CI** (PHP 8.3 .. 8.4) | [![CI](https://github.com/puzzle-org/configuration/actions/workflows/ci.yml/badge.svg)](https://github.com/puzzle-org/amqp/actions/workflows/ci.yml)
-| **Packagist**           | [![Latest Stable Version](https://poser.pugx.org/puzzle/amqp/v/stable.png)](https://packagist.org/packages/puzzle/amqp) [![Total Downloads](https://poser.pugx.org/puzzle/amqp/downloads.svg)](https://packagist.org/packages/puzzle/amqp) |
+| Service                    | Result |
+|----------------------------| --- |
+| **CI** (PHP 8.3, 8.4, 8.5) | [![CI](https://github.com/puzzle-org/configuration/actions/workflows/ci.yml/badge.svg)](https://github.com/puzzle-org/amqp/actions/workflows/ci.yml)
+| **Packagist**              | [![Latest Stable Version](https://poser.pugx.org/puzzle/amqp/v/stable.png)](https://packagist.org/packages/puzzle/amqp) [![Total Downloads](https://poser.pugx.org/puzzle/amqp/downloads.svg)](https://packagist.org/packages/puzzle/amqp) |
 
 Configuration
 -------------
@@ -115,6 +115,11 @@ class ExampleWorker implements Worker
 
 BC Breaks changelog
 -------------------
+
+**5.x -> 8.x**
+- Since version 8.3 : version name follows minimal supported php version
+- For version changelog : see Github's release description
+
 **4.x -> 5.x**
 
  - Drop support for php 5.6 & 7.x

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "knplabs/gaufrette": "~0.2",
         "puzzle/assert": "~1.1",
         "pimple/pimple": "~3.0",
-        "odolbeau/rabbit-mq-admin-toolkit": "v5.4.0",
+        "odolbeau/rabbit-mq-admin-toolkit": "^5.4.1",
         "behat/behat": "~3.3",
         "symfony/debug": "~3.2",
         "groall/rabbitmq-http-api-client-php": "^0.2.4"

--- a/docker/images/apache/Dockerfile
+++ b/docker/images/apache/Dockerfile
@@ -19,22 +19,9 @@ RUN apt-get update && \
 
 ENV RABBITMQ_VERSION 0.11.0
 
-RUN cd /tmp && \
-    curl --stderr - -L -O https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v${RABBITMQ_VERSION}.tar.gz && \
-    tar xf v${RABBITMQ_VERSION}.tar.gz && \
-    cd rabbitmq-c-${RABBITMQ_VERSION} && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    cmake --build . && \
-    cd /tmp && \
-    rm -rf rabbitmq-c-${RABBITMQ_VERSION} && \
-    rm v${RABBITMQ_VERSION}.tar.gz
-
-RUN pecl install xdebug amqp-1.11.0 && \
+RUN pecl install xdebug amqp && \
     docker-php-ext-enable xdebug amqp
 
 WORKDIR /var/www/puzzle-amqp
 
 COPY php.ini /usr/local/etc/php/conf.d
-

--- a/docker/images/apache/Dockerfile
+++ b/docker/images/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-cli
+FROM php:8.5-cli
 
 RUN echo 'APT::Install-Recommends "0";' >>/etc/apt/apt.conf.d/99-recommends && \
     echo 'APT::Install-Suggests "0";' >>/etc/apt/apt.conf.d/99-suggests

--- a/docker/images/phpunit/whalephant.yml
+++ b/docker/images/phpunit/whalephant.yml
@@ -1,6 +1,6 @@
 name: puzzle-amqp
 php:
-    version: 8.4
+    version: 8.5
 extensions:
     - xdebug
 ini:

--- a/makefiles/composer.mk
+++ b/makefiles/composer.mk
@@ -20,8 +20,10 @@ COMPOSER_OPTIONS=--no-plugins
 
 composer = $(DOCKER_RUN) --rm \
                 -v ${HOST_SOURCE_PATH}:/var/www/app \
-                -v ~/.cache/composer:/tmp/composer \
-                -e COMPOSER_CACHE_DIR=/tmp/composer \
+                -v ~/.cache/composer:/tmp/composer-cache \
+                -e COMPOSER_CACHE_DIR=/tmp/composer-cache \
+                -v ~/.config/composer:/tmp/composer-home \
+                -e COMPOSER_HOME=/tmp/composer-home \
                 -w /var/www/app \
                 -u ${USER_ID}:${GROUP_ID} \
                 composer:${COMPOSER_VERSION} ${COMPOSER_OPTIONS} $(COMPOSER_INTERACTIVE) $1 $2
@@ -77,10 +79,13 @@ vendor/: composer.json
 #------------------------------------------------------------------------------
 
 .PHONY: -composer-init
--composer-init: ~/.cache/composer
+-composer-init: ~/.cache/composer ~/.config/composer
 
 ~/.cache/composer:
 	mkdir -p ~/.cache/composer
+
+~/.config/composer:
+	mkdir -p ~/.config/composer
 
 #------------------------------------------------------------------------------
 

--- a/makefiles/phpunit.mk
+++ b/makefiles/phpunit.mk
@@ -34,6 +34,7 @@ clean-phpunit: clean-phpunit-image
 
 clean-phpunit-image:
 	-rm docker/images/phpunit/Dockerfile
+	-rm docker/images/phpunit/php.ini
 	docker rmi ${IMAGE_NAME}
 
 .PHONY: phpunit phpunit-dox phpunit-coverage create-phpunit-image clean-phpunit-image

--- a/src/Messages/BodyFactories/Standard.php
+++ b/src/Messages/BodyFactories/Standard.php
@@ -16,16 +16,16 @@ use Puzzle\AMQP\Messages\TypedBodyFactory;
 class Standard implements BodyFactory
 {
     use LoggerAwareTrait;
-    
+
     private array
         $factories;
-    
+
     public function __construct()
     {
         $this->initializeFactories();
         $this->logger = new NullLogger();
     }
-    
+
     private function initializeFactories(): void
     {
         $this->factories = [
@@ -34,23 +34,23 @@ class Standard implements BodyFactory
             ContentType::BINARY => new TypedBodyFactories\Binary(),
         ];
     }
-    
+
     public function handleContentType($contentType, TypedBodyFactory $factory): static
     {
         $this->factories[$contentType] = $factory;
-        
+
         return $this;
     }
-    
+
     public function build($contentType, $contentAsTransported): Body
     {
-        if(isset($this->factories[$contentType]))
+        if(!is_null($contentType) && isset($this->factories[$contentType]))
         {
             return $this->factories[$contentType]->build($contentAsTransported);
         }
-        
+
         $this->logger->warning(__CLASS__ . ": unknown content-type, use empty body");
-        
+
         return new EmptyBody();
     }
 }


### PR DESCRIPTION
Fixed deprecation `Using null as an array offset is deprecated, use an empty string instead`
Some third parties triggers deprecations

`knplabs/gaufrette`
- `vendor/knplabs/gaufrette/src/Gaufrette/Adapter/InMemory.php` : `Non-canonical cast (integer) is deprecated, use the (int) cast instead`
- `vendor/knplabs/gaufrette/src/Gaufrette/Adapter/InMemory.php:84`: `Non-canonical cast (boolean) is deprecated, use the (bool) cast instead`

`odolbeau/rabbit-mq-admin-toolkit`
- `Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in /usr/src/puzzle-amqp/vendor/odolbeau/rabbit-mq-admin-toolkit/src/Bab/RabbitMq/HttpClient/CurlClient.php on line 67`

`groall/rabbitmq-http-api-client-php`
- `Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in /usr/src/puzzle-amqp/vendor/groall/rabbitmq-http-api-client-php/sources/RabbitMqHttpApiClient.php on line 51`